### PR TITLE
set IFS to null when updating DOCKER_TAGS_ARG

### DIFF
--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -19,7 +19,11 @@ parse_tags_to_docker_arg() {
     fi
   done
 
+  # Set IFS to null to stop "," from breaking bash substitution
+  local old_ifs="$IFS"
+  local IFS=
   DOCKER_TAGS_ARG="$(eval echo $docker_arg)"
+  local IFS="$old_ifs"
 }
 
 pull_images_from_cache() {


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
Issue comes when the PARAM_IMAGE, PARAM_REGISTRY or PARAM_TAG includes a ```,```

This can happen if the CircleCI parameter value is set to a variable which may include some bash substitution. 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

If  PARAM_IMAGE, PARAM_REGISTRY or PARAM_TAG includes a ```,``` it can cause an issue when setting DOCKER_TAGS_ARG as those values will be split. 

If using bash substitution like ```${PARAM_IMAGE,,}``` it will fail because of the IFS. 

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
